### PR TITLE
E_STRICT compatibility fix for kyTicketTimeTrack

### DIFF
--- a/kyTicketTimeTrack.php
+++ b/kyTicketTimeTrack.php
@@ -194,7 +194,7 @@ class kyTicketTimeTrack extends kyObjectBase {
 	 * @param int $ticket_id Ticket identifier.
 	 * @return kyResultSet
 	 */
-	static public function getAll($ticket_id) {
+	static public function getAll($ticket_id = null) {
 		$search_parameters = array('ListAll');
 
 		$search_parameters[] = $ticket_id;
@@ -209,7 +209,9 @@ class kyTicketTimeTrack extends kyObjectBase {
 	 * @param int $id Ticket time track identifier.
 	 * @return kyTicketTimeTrack
 	 */
-	static public function get($ticket_id, $id) {
+	static public function get($params) {
+		list($ticket_id, $id) = $params;
+		
 		return parent::get(array($ticket_id, $id));
 	}
 


### PR DESCRIPTION
Matched KyObjectBase `getAll` and `get` function signatures.